### PR TITLE
Fixed text encoding to UTF-8 and added bulleted list to README

### DIFF
--- a/IDEAS
+++ b/IDEAS
@@ -1,6 +1,6 @@
-ÛßßßßßßßßßßßßßßßßßßÛ	+ Big routine ('demo part')	T Trug
-Û Unreal 2 - Ideas Û	- Small routine			W Wildfire
-ÛÜÜÜÜÜÜÜÜÜÜÜÜÜÜÜÜÜÜÛ	? Depends			P Psi
+â–ˆâ–€â–€â–€â–€â–€â–€â–€â–€â–€â–€â–€â–€â–€â–€â–€â–€â–€â–€â–ˆ	+ Big routine ('demo part')	T Trug
+â–ˆ Unreal 2 - Ideas â–ˆ	- Small routine			W Wildfire
+â–ˆâ–„â–„â–„â–„â–„â–„â–„â–„â–„â–„â–„â–„â–„â–„â–„â–„â–„â–„â–ˆ	? Depends			P Psi
 Note: This is not a list of what WILL be in the demo, but a list of what
 could be in the demo. Some parts won't be finished in time (surprise!?)
 and some will be rejected later after experimenting.... 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This release is made to celebrate the 20th anniversary of the demo.
 
 Wikipedia links :
 
-[Future Crew](http://www.wikipedia.org/wiki/Future_Crew)
-[Second Reality](http://www.wikipedia.org/wiki/Second_reality)
+- [Future Crew](http://www.wikipedia.org/wiki/Future_Crew)
+- [Second Reality](http://www.wikipedia.org/wiki/Second_reality)
 
 This is free and unencumbered software released into the public domain.
 

--- a/SCRIPT
+++ b/SCRIPT
@@ -38,7 +38,7 @@ MARVEL	Loppuscrollifontti		PSI?	320x400	?	16aa	-
 MARVEL	AlkuHorisontti (widescreen)	WILDF	320x200	640x150	63	-
 MARVEL	Siisti kuva 2 (lens/zoomer)	PSI	320x200	256x200	63	-
 MARVEL	FC-logo (loppuun)		PSI	320x400	320x400	127	-
-TRUG	Praxis rÑjÑhdys 		WILDF	320x200 320x200	255	80
+TRUG	Praxis r√§j√§hdys 		WILDF	320x200 320x200	255	80
 MARVEL	Siisti 3				320x400 200x400	63	-
 [1] tausta puuttuu
 
@@ -48,76 +48,76 @@ MARVEL	Siisti 3				320x400 200x400	63	-
 	~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 PSI	Setup screen
- 	- grafiikkatilassa (mutta nÑyttÑÑ tekstiltÑ)
-	- kun kaikki valittu, lentÑÑ face kohti ruutua ja jymÑhtÑÑ siihen
-	- hidas fade mustaksi facen vÑristÑ
+ 	- grafiikkatilassa (mutta n√§ytt√§√§ tekstilt√§)
+	- kun kaikki valittu, lent√§√§ face kohti ruutua ja jym√§ht√§√§ siihen
+	- hidas fade mustaksi facen v√§rist√§
 	
 (music) Leffatyylimusat
 
 WILDF	Alkutekstit I
 	- mustalle fadeaa yksinkertaisella leffafontilla 
-PIXEL 	  [fontti 3 vÑriÑ]
+PIXEL 	  [fontti 3 v√§ri√§]
 	"A FUTURE CREW production" [fade=>black]
 	"First presented at Assembly '93" [fade=>black]
 	[fade=>horisonttikuva]
 MARVEL	[ Horisonttikuva on 320x400 resoluutiossa widescreen.
-	  Itse kuva kooltaan 640x300 pikseliÑ. ]
+	  Itse kuva kooltaan 640x300 pikseli√§. ]
 	- Kuvaa scrollataan taustalla hitaasti vasemmalle, seuraavat
-	  tekstit fadetaan kuvan pÑÑlle
+	  tekstit fadetaan kuvan p√§√§lle
 	"Graphics by ..." [xfade]
-(sfx)	- Surround jyrinÑ voimistuu hiljalleen (takaa, surround)
+(sfx)	- Surround jyrin√§ voimistuu hiljalleen (takaa, surround)
 	"Music by ..." [xfade]			
-	- JyrinÑ nyt voimakasta (ja korkeaa) 
-	  (alus tulossa takaa (huom! doppler ilmiî!))
+	- Jyrin√§ nyt voimakasta (ja korkeaa) 
+	  (alus tulossa takaa (huom! doppler ilmi√∂!))
 	"Code by ..." [xfade]
 	
 PSI	Alkutekstit II (Vector Part 0)
-?	- Takaa lentÑÑ ylisuuri 'massiivi' alus kohti horisonttia
+?	- Takaa lent√§√§ ylisuuri 'massiivi' alus kohti horisonttia
 	  (alus yksinkertaisen muotoinen, mutta paljon detailia yms.
 	  esim textureilla)
-(sfx)	- Aluksen ohilentoÑÑnet
-	- Alus kiihdyttÑÑ lujaa kohti horisonttia
+(sfx)	- Aluksen ohilento√§√§net
+	- Alus kiihdytt√§√§ lujaa kohti horisonttia
 	- lopulta alus on pikselin kokoinen
 
 TRUG	Alkutekstit III
-	- Kun se pienenee pikselin kokoiseksi rÑjÑhtÑÑ piste (Praxis style)
-TRUG	- RÑjÑhdysvalli etenee kohti katsojaa (flic)
-	- vallin osuessa katsojaan ruutu jÑÑ valkoiseksi
+	- Kun se pienenee pikselin kokoiseksi r√§j√§ht√§√§ piste (Praxis style)
+TRUG	- R√§j√§hdysvalli etenee kohti katsojaa (flic)
+	- vallin osuessa katsojaan ruutu j√§√§ valkoiseksi
 	- Valkoisesta fadeaa ensin mustavalkoisena demon logo
 PIXEL	[ Logo on 320x200x256, valkotaustainen ]
-	- Logoon fadeautuvat vÑrit
+	- Logoon fadeautuvat v√§rit
 
-(music)	Teknomaista trackkiÑ
+(music)	Teknomaista trackki√§
 
 PSI	Glenz part 
-	- ruutu kÑÑntyy alaspÑin keskustansa ympÑri (precalc logon aikana)
-	  jolloin alkuperÑinen logo jÑÑ kÑÑntvÑn levyn alle
-	- lopulta nÑkyy vain blokin reuna jonka alapuolella logo oli
-PIXEL	- blokin ylÑpuolella on 1 vÑrinen simppeli muoto (smoothattu
+	- ruutu k√§√§ntyy alasp√§in keskustansa ymp√§ri (precalc logon aikana)
+	  jolloin alkuper√§inen logo j√§√§ k√§√§ntv√§n levyn alle
+	- lopulta n√§kyy vain blokin reuna jonka alapuolella logo oli
+PIXEL	- blokin yl√§puolella on 1 v√§rinen simppeli muoto (smoothattu
 	  fadella)
 	- blokki pomppii alas
-	- blokin pÑÑlle tippuu glenzi (precalcattu jello)
-	- kun glenzi on pysÑhtynyt, levy laskeutuu alas ja vain glenzi 
-	  jÑÑ ruutuun
-	- glenzi alkaa pyîriÑ
-	- sen sisÑlle fadeautuu toinen glenzi
-	- molemmat pyîrivÑt
+	- blokin p√§√§lle tippuu glenzi (precalcattu jello)
+	- kun glenzi on pys√§htynyt, levy laskeutuu alas ja vain glenzi 
+	  j√§√§ ruutuun
+	- glenzi alkaa py√∂ri√§
+	- sen sis√§lle fadeautuu toinen glenzi
+	- molemmat py√∂riv√§t
 	- ulommainen suurenee yli ruudun
-	- pienempi jÑÑ keskelle 'valonlÑhteeksi'
+	- pienempi j√§√§ keskelle 'valonl√§hteeksi'
 	
 TRUG	Dottunnel
-	- glenzin ympÑrille tulee dottitunneli
-	- lopuksi tunneli himmenee valonlÑhteen mukana
+	- glenzin ymp√§rille tulee dottitunneli
+	- lopuksi tunneli himmenee valonl√§hteen mukana
 	- eli siis musta ruutu 
 
 PSI	Interferenssi
 	- EGA tilaan
 
 PSI	Techno
-	- teknobaarit pyîrivÑt jne.
+	- teknobaarit py√∂riv√§t jne.
 	- lopuksi vauhti kiihtyy, kunnes
 (sfx)	- pamahdus
-	- ruutu pysÑhtyy (vÑlÑhtÑÑ samalla)
+	- ruutu pys√§htyy (v√§l√§ht√§√§ samalla)
 	- hetken paikallaan
 	- MCGA tweakkiin
 PIXEL	- siisti kuva [320x400x256]
@@ -126,7 +126,7 @@ WILDF	- panic style: ruutu pienenee pisteeksi ja musa samalla sammahtaa
 	- Taukoa noin 5 sec.
 
 TRUG	MountainScroll
-	- puut ilmestyvÑt
+	- puut ilmestyv√§t
 	- scrolli fadeaa
 	- scrolli scrollaa yli
 	[ scrolli on kuva 320x31 joka on jokin logo]
@@ -134,22 +134,22 @@ TRUG	MountainScroll
 
 PSI	Lens
 MARVEL	[ 320x400x64 siisti kuva]
-	- linssi (3 vÑrin varjostus) pomppii pari kertaa
+	- linssi (3 v√§rin varjostus) pomppii pari kertaa
 
 PSI	Rotazoomer
-	- zoomaillaan ja pyîritellÑÑn linssikuvaa
+	- zoomaillaan ja py√∂ritell√§√§n linssikuvaa
 	- kuva fadeautuu valkoiseksi
 
 WILDF	Plasma
 
 WILDF	Plasmacube
-	- plasmacube on harmaan horisonttitason pÑÑllÑ (siis myîs varjo)
-	- pyîrii etc kivaa
-	- lentelee ympÑri
+	- plasmacube on harmaan horisonttitason p√§√§ll√§ (siis my√∂s varjo)
+	- py√∂rii etc kivaa
+	- lentelee ymp√§ri
 	- kahdentuminen?
 
 PSI	MiniVectorBalls
-	- kaikkea kivaa, suihkulÑhde jne...
+	- kaikkea kivaa, suihkul√§hde jne...
 	- pomppuja
 	- poistuvat pomppien/kulkien/etc
 
@@ -157,9 +157,9 @@ TRUG	Raytrace Scroll
 	- vesisinus ja peilipallo + tietty scrolli
 
 PSI	Comanche = 3D-Sinusfield
-	- fade ?sinisestÑ efektiin
+	- fade ?sinisest√§ efektiin
 	- aaltoileva aavikonpinta
-	- lopulta kamera nousee ylîspÑin ja efekti himmenee mustaksi
+	- lopulta kamera nousee yl√∂sp√§in ja efekti himmenee mustaksi
 
 PSI	Jellykuva (MARVEL)
 	
@@ -174,8 +174,8 @@ PIXEL	Loppukuva = FC-Logo
 ?	EndScroller
 	- 320x400x256
 MARVEL	[ fontti 12x24x32 ]
-	- creditseistÑ pienet kuvat scrollaavat
-	- greetingsit ja muut mîlinÑt
+	- creditseist√§ pienet kuvat scrollaavat
+	- greetingsit ja muut m√∂lin√§t
 	
 SOME1	The End
 	- dossiin tai looppi (alussa valittavissa)

--- a/VECSCR
+++ b/VECSCR
@@ -3,92 +3,92 @@
 +=code -=3DS
 	
 + Ruutu on musta
-+ T„hdet v„l„ht„v„t ja avaruus leimahtaa (=back from hyperspace)
-- Alus suhahtaa vauhdilla kameran alta poisp„in jarruttaen.
-  (nopeus on per„isin hyperspacesta poistumisesta)
-- Alus pys„htyy kun se on noin nelj„sosaruudun kokoinen.
-+ Taustalla (aluksen edessa = aluksen osittain peitt„m„n„) n„kyy paljon 
++ TÃ¤hdet vÃ¤lÃ¤htÃ¤vÃ¤t ja avaruus leimahtaa (=back from hyperspace)
+- Alus suhahtaa vauhdilla kameran alta poispÃ¤in jarruttaen.
+  (nopeus on perÃ¤isin hyperspacesta poistumisesta)
+- Alus pysÃ¤htyy kun se on noin neljÃ¤sosaruudun kokoinen.
++ Taustalla (aluksen edessa = aluksen osittain peittÃ¤mÃ¤nÃ¤) nÃ¤kyy paljon 
   pikku aluksia (=polygoneja) Niihin sinus/spline kaukana
 - 3 sec paikallaan
-- kamera kiert„„ kerran aluksen ymp„ri oikealta stylesti (yl„puolelta)
-- kamera lopulta samassa suunnassa kuin alunperin, mutta l„hemp„n„
+- kamera kiertÃ¤Ã¤ kerran aluksen ympÃ¤ri oikealta stylesti (ylÃ¤puolelta)
+- kamera lopulta samassa suunnassa kuin alunperin, mutta lÃ¤hempÃ¤nÃ¤
 
-- kamera paikallaan ison aluksen p„„ll„ l„hell„ sen pintaa (n„kyy vain
-  pala pintaa jossa tutka-antenni, joka py”rii, sek„ taustalla avaruutta,
-  jonka ep„keskell„ erottuu juuri oma alus)
-- antenni osoittaa aluksi suoraan eteenp„in (=oikealle omasta aluksesta) 
-  kokoajan tasaisella nopeudella py”rien. Antenni on oikeassa
+- kamera paikallaan ison aluksen pÃ¤Ã¤llÃ¤ lÃ¤hellÃ¤ sen pintaa (nÃ¤kyy vain
+  pala pintaa jossa tutka-antenni, joka pyÃ¶rii, sekÃ¤ taustalla avaruutta,
+  jonka epÃ¤keskellÃ¤ erottuu juuri oma alus)
+- antenni osoittaa aluksi suoraan eteenpÃ¤in (=oikealle omasta aluksesta) 
+  kokoajan tasaisella nopeudella pyÃ¶rien. Antenni on oikeassa
   alakulmassa.
 - kun antenni on tehnyt vajaan kierroksen ja osoittaa kohti omaa alusta,
-  se pys„htyy
+  se pysÃ¤htyy
 - 1 sec tauko
-- antenni alkaa taas p”yri„
-- viisi vihollisalusta lent„v„t kameran takaa l„helt„ surroundina vasemmasta
+- antenni alkaa taas pÃ¶yriÃ¤
+- viisi vihollisalusta lentÃ¤vÃ¤t kameran takaa lÃ¤heltÃ¤ surroundina vasemmasta
   reunasta kohti omaa alusta 
-- kamera l„htee seuraamaan
-- lennet„„n noin 2 sec
-- alukset siirtyv„t muodostelmaan
+- kamera lÃ¤htee seuraamaan
+- lennetÃ¤Ã¤n noin 2 sec
+- alukset siirtyvÃ¤t muodostelmaan
 
-- yleiskuva jossa n„kyv„t sek„ muodostelma ett„ iso alus
+- yleiskuva jossa nÃ¤kyvÃ¤t sekÃ¤ muodostelma ettÃ¤ iso alus
 - kamera taas muodostelman taakse, muodostelma hajoaa
-- johtoalus j„„ taakse (eli kamera suhahtaa sen yli)
-- kamera alkaa seurata kahta oikeanpuoleista alusta (kiihdytt„„)
-- oikeanpuoleiset kaartavat oikealle kauemmas aluksesta, k„„ntyv„t
-  kohti sit„ ja hidastavat 
+- johtoalus jÃ¤Ã¤ taakse (eli kamera suhahtaa sen yli)
+- kamera alkaa seurata kahta oikeanpuoleista alusta (kiihdyttÃ¤Ã¤)
+- oikeanpuoleiset kaartavat oikealle kauemmas aluksesta, kÃ¤Ã¤ntyvÃ¤t
+  kohti sitÃ¤ ja hidastavat 
 - viholliset ampuvat
-- kamera ison aluksen l„helt„ kohti vihollismuodostelmaa, paukut
-  osuvat l„helle kameraa (=menev„t juuri taakse). Vihollisalukset
-  n„ytt„v„t oman aluksen pinnalta pisteilt„, joista l„htee paukkuja
+- kamera ison aluksen lÃ¤heltÃ¤ kohti vihollismuodostelmaa, paukut
+  osuvat lÃ¤helle kameraa (=menevÃ¤t juuri taakse). Vihollisalukset
+  nÃ¤yttÃ¤vÃ¤t oman aluksen pinnalta pisteiltÃ¤, joista lÃ¤htee paukkuja
 - kuva taas kahden vihollisen takaa
-- n„kyy kun pohjasta ilmestyy omia aluksia (putoavat) ja samalla
+- nÃ¤kyy kun pohjasta ilmestyy omia aluksia (putoavat) ja samalla
   etualalla juuri ampuneet viholliset
 - omat alukset kaartavat peliin ison aluksen alta kohti kameraa
-  ja kahta vihollista (viholliset t„ytt„v„t noin puoli ruutua, 
+  ja kahta vihollista (viholliset tÃ¤yttÃ¤vÃ¤t noin puoli ruutua, 
   vasemmassa reunassa)
 - omat ampuvat paukkusarjan
 - viholliset kaartavat, toinen oikelle, toinen vasemmalle,
-  kaarto menee pois ruudusta sill„ kamera jatkaa suoraan kohti
+  kaarto menee pois ruudusta sillÃ¤ kamera jatkaa suoraan kohti
   omia
 - laserit suhahtavat kameran alta
 - omat alukset suhahtavat kameran alta (immelman)
-- immelmanin lopuksi suhahtavat takaisin kameran ylt„
-- omat alukset jakautuvat kahteen ryhm„„n, joista oikealle
+- immelmanin lopuksi suhahtavat takaisin kameran yltÃ¤
+- omat alukset jakautuvat kahteen ryhmÃ¤Ã¤n, joista oikealle
   kaartavaa alkaa kamera seurata
-- kamera omien takana, vihollinen n„kyy ampumalinjalla
-- omat heitt„v„t paukkupinkan
+- kamera omien takana, vihollinen nÃ¤kyy ampumalinjalla
+- omat heittÃ¤vÃ¤t paukkupinkan
 - PUM!
-- omat kaartavat aluksen takap„„n ymp„ri
-- kun ne ovat viel„ kaarteessa, tulee vasemmalta yll„tt„en paukkusuihku
+- omat kaartavat aluksen takapÃ¤Ã¤n ympÃ¤ri
+- kun ne ovat vielÃ¤ kaarteessa, tulee vasemmalta yllÃ¤ttÃ¤en paukkusuihku
   joka osuu niiden kattoon ja PUM!
 - kamera vaihtuu vasemmalle menneen partion taakse (omat) joka on 
   nyt melkein aluksen keulan kohdalla
-- ruudussa juuri n„kyy toisen aluksen r„j„hdys 
-- lennet„„n r„j„hdyspilven l„pi
-- omat kaartavat jyrk„sti oman ison aluksen alle
-- kamera lent„„ per„ss„ (katsoja saa ensivilkauksen pohjasta)
-- alukset lent„v„t juuri dockicompleksin alta keulan puolelta
-- kamera loikkaa kahden j„ljell„olevan vihollisaluksen taakse
+- ruudussa juuri nÃ¤kyy toisen aluksen rÃ¤jÃ¤hdys 
+- lennetÃ¤Ã¤n rÃ¤jÃ¤hdyspilven lÃ¤pi
+- omat kaartavat jyrkÃ¤sti oman ison aluksen alle
+- kamera lentÃ¤Ã¤ perÃ¤ssÃ¤ (katsoja saa ensivilkauksen pohjasta)
+- alukset lentÃ¤vÃ¤t juuri dockicompleksin alta keulan puolelta
+- kamera loikkaa kahden jÃ¤ljellÃ¤olevan vihollisaluksen taakse
   katse kohti omaa alusta ja sen pohjaa. (vihollisalukset noin
   1/6 ruutua)
-- oman aluksen alta kaartavat 2 j„ljell„olevaa (joita juuri trackattiin)
-- omat laukaisevat paukut yl”salaisin kaartaen (siististi)
+- oman aluksen alta kaartavat 2 jÃ¤ljellÃ¤olevaa (joita juuri trackattiin)
+- omat laukaisevat paukut ylÃ¶salaisin kaartaen (siististi)
 - viholliset PUM!
-- omat kaartavat kohti keulaa kameran edest„ (immelman part 2)
-- kuva vihollisen johtoaluksen takaa (edess„ oma iso alus)
-- johtoalus k„„ntyy paikallaan, ja painaa kaasua
-- kamera j„„ paikalleen
+- omat kaartavat kohti keulaa kameran edestÃ¤ (immelman part 2)
+- kuva vihollisen johtoaluksen takaa (edessÃ¤ oma iso alus)
+- johtoalus kÃ¤Ã¤ntyy paikallaan, ja painaa kaasua
+- kamera jÃ¤Ã¤ paikalleen
 - taukoa
-- omat h„vitt„j„t lent„v„t kameran ohi ja samalla kamera k„„ntyy
+- omat hÃ¤vittÃ¤jÃ¤t lentÃ¤vÃ¤t kameran ohi ja samalla kamera kÃ¤Ã¤ntyy
   niiden menosuuntaan
-- kuva kaukaa ylh„„lt„, n„kyy kun omat saavat vihollista kiinni
-- kuva omien alusten per„st„
+- kuva kaukaa ylhÃ¤Ã¤ltÃ¤, nÃ¤kyy kun omat saavat vihollista kiinni
+- kuva omien alusten perÃ¤stÃ¤
 - omat alkavat ampua PALJON!
 - kuvakulma vihollisesta omiin
 - kuvakulma omiin vihollisesta 
 - kuvakulma vihollisesta omiin
 - PUMPUM!
-- omat kaartavat oikealle U-k„„nn”ksen
-- kamera j„„ katsomaan niiden matkaa kohti omaa alusta
+- omat kaartavat oikealle U-kÃ¤Ã¤nnÃ¶ksen
+- kamera jÃ¤Ã¤ katsomaan niiden matkaa kohti omaa alusta
 
 Faces:	Tarvelista:
 200	Iso alus (1)


### PR DESCRIPTION
- Some characters were appearing incorrectly in the `IDEAS`, `SCRIPT`, and `VECSCR` files. The encoding for those files has been changed so they are now readable in UTF-8.
- The Wikipedia links for [Future Crew](http://www.wikipedia.org/wiki/Future_Crew) and [Second Reality](http://www.wikipedia.org/wiki/Second_reality) in the `README.md` have been moved into a bulleted list for better readability.